### PR TITLE
slash command

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ To run this integration you need:
 
 1. A **network connected device running python** like Raspberry Pi or any other Linux device which supports python and the required packages or **running Docker**
 2. A **[Mattermost account](http://www.mattermost.org/)** where [incoming webhooks are enabled](https://docs.mattermost.com/developer/webhooks-incoming.html) and
-optionally [slash-commands enabled](ttps://docs.mattermost.com/developer/slash-commands.html)
+optionally [slash-commands enabled](https://docs.mattermost.com/developer/slash-commands.html)
 
 ## Linux/Ubuntu 14.04 Install
 

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ This integration also works with Microsoft Windows:
     `sudo supervisorctl`  
     `supervisor> start Rss-Atom-Feed-Integration-for-Mattermost`
 
-## Docker deploiement
+## Docker deployment
 
 This integration is also available as a Docker image.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # RSS- and Atom-Feed Integration Service for Mattermost
 
-This integration service posts RSS feeds into specific Mattermost channels by formatting output from html to text 
-via [Mattermost's incoming webhooks](https://github.com/mattermost/platform/blob/master/doc/integrations/webhooks/Incoming-Webhooks.md).
+This integration service posts RSS feeds into specific Mattermost channels by formatting output from html to text
+via [Mattermost's incoming webhooks](https://docs.mattermost.com/developer/webhooks-incoming.html). It can also be managed through [slash-commands](https://docs.mattermost.com/developer/slash-commands.html).
 
 <img src="https://github.com/bitbackofen/Rss-Atom-Feed-Integration-for-Mattermost/blob/master/Rss-Atom-Feed-Integration-for-Mattermost.png" width="250">
 
@@ -9,16 +9,17 @@ via [Mattermost's incoming webhooks](https://github.com/mattermost/platform/blob
 
 To run this integration you need:
 
-1. A **network connected device running python** like Raspberry Pi or any other Linux device which supports python and the required packages
-2. A **[Mattermost account](http://www.mattermost.org/)** where [incoming webhooks are enabled](https://github.com/mattermost/platform/blob/master/doc/integrations/webhooks/Incoming-Webhooks.md#enabling-incoming-webhooks)
+1. A **network connected device running python** like Raspberry Pi or any other Linux device which supports python and the required packages or **running Docker**
+2. A **[Mattermost account](http://www.mattermost.org/)** where [incoming webhooks are enabled](https://docs.mattermost.com/developer/webhooks-incoming.html) and
+optionally [slash-commands enabled](ttps://docs.mattermost.com/developer/slash-commands.html)
 
 ## Linux/Ubuntu 14.04 Install
 
-The following procedure shows how to install this project on a Linux device running Ubuntu 14.04. 
-The following instructions work behind a firewall as long as the device has access to your Mattermost instance. 
+The following procedure shows how to install this project on a Linux device running Ubuntu 14.04.
+The following instructions work behind a firewall as long as the device has access to your Mattermost instance.
 
-To install this project using a Linux-based device, you will need Python 2.7 or a compatible version. 
-Other compatible operating systems and Python versions should also work. 
+To install this project using a Linux-based device, you will need Python 2.7 or a compatible version.
+Other compatible operating systems and Python versions should also work.
 
 Here's how to start:
 
@@ -28,7 +29,14 @@ Here's how to start:
     2. Under **Add a new incoming webhook** select the channel in which you want Feed notifications to appear, then click **Add** to create a new entry.
     3. Copy the contents next to **URL** of the new webhook you just created (we'll refer to this as `https://<your-mattermost-webhook-URL>`).
 
-2. **Set up this project to run on your Linux device**
+2. **Set up a new slash-commands on your Mattermost instance to manage the feeds**
+    1. In the Integrations Menu, go to **Slash Commands**.
+    2. Under **Add a new slash command**, enter the name of your command, a description and the word to trigger the command. The **Request URL** is simply the address to reach the machine where the project run. The default port is `8080` but is overriden by `integration_listening_port`.  
+    You can optionally opt-in for **Autocompletion**, and use this value :  
+      `/rss-bot list | add <Feed Name> <Feed URL> [<Image URL>] [<Show Name>] [<Show Title>] [<Show Description>] [<Show URL>] | remove <Feed Name>`
+    3. Click **Add** to create the new command and copy the **Token** value for the command you just created. We'll refer to it as `<your-slash-command-token>`.
+
+3. **Set up this project to run on your Linux device**
     1. Set up a **Linux Ubuntu 14.04** server either on your own machine or on a hosted service, like AWS.
     2. **SSH** into the machine, or just open your terminal if you're installing locally.
     3. Confirm **Python 2.7** or a compatible version is installed by running:  
@@ -123,3 +131,21 @@ This integration also works with Microsoft Windows:
 4. Start the feedfetcher:  
     `sudo supervisorctl`  
     `supervisor> start Rss-Atom-Feed-Integration-for-Mattermost`
+
+## Docker deploiement
+
+This integration is also available as a Docker image.
+
+1. Set up any box with **Docker** on it or access to a remote **Docker Host**.
+2. Clone this GitHub repository:  
+`git clone https://github.com/bitbackofen/Rss-Atom-Feed-Integration-for-Mattermost.git`  
+`cd Rss-Atom-Feed-Integration-for-Mattermost`
+3. Copy sample Compose and Feeds files:  
+`cp docker-compose.yml.sample docker-compose.yml`  
+`cp feeds.env.sample feeds.env`
+4. Edit the environment variables of `docker-compose.yml` to suit your needs. If a variable is omitted, the default value is used (except for `MATTERMOST_HOOK_URL` and `MATTERMOST_CMD_TOKEN`)
+5. Complete `feeds.env` with the desired RSS feeds
+6. Spin up the container with `docker-compose up`  
+You should see your feeds scrolling through. Check your configured Mattermost channel for the new feeds.
+If everything works fine:  
+7. Start the container with `docker-compose up -d`

--- a/docker-compose.yml.sample
+++ b/docker-compose.yml.sample
@@ -4,9 +4,18 @@ services:
     build: .
     environment:
       MATTERMOST_HOOK_URL: 'https://<your-mattermost-webhook-URL>'
+      MATTERMOST_CMD_TOKEN: '<your-slash-command-token>'
       RSS_SILENT_MODE: 'True'
       RSS_SHOW_NAME: 'False'
+      RSS_SHOW_TITLE: 'True'
+      RSS_SHOW_DESCR: 'True'
       RSS_SHOW_URL: 'False'
+      RSS_VERIFY_SSL_CERT: 'False'
+      RSS_SKIP_INIT_ARTICLE: 'False'
+      INTEGRATION_BOT_NAME: 'RSS-Bot'
+      INTEGRATION_BOT_IMG: ''
+      INTEGRATION_LISTENING_ADDR: ''
+      INTEGRATION_LISTENING_PORT: '8080'
       MATTERMOST_CHANNEL: 'rss-stream'
     env_file:
       - feeds.env

--- a/feedfetcher.py
+++ b/feedfetcher.py
@@ -61,7 +61,11 @@ if __name__ == "__main__":
                 feed.NewTitle = d['entries'][0]['title']
                 feed.ArticleUrl = d['entries'][0]['link']
                 feed.Description = d['entries'][0]['description']
-                if feed.LastTitle != feed.NewTitle:
+                if settings.skip_init_article and len(feed.LastTitle) <= 0:
+                    if not silent_mode:
+                        logging.debug('Initializing feed: ' + feed.Name + '. Skipping the last news: ' + feed.NewTitle)
+                    feed.LastTitle = feed.NewTitle
+                elif feed.LastTitle != feed.NewTitle:
                     if not silent_mode:
                         logging.debug('Feed url: ' + feed.Url)
                         logging.debug('Title: ' + feed.NewTitle)

--- a/feedfetcher.py
+++ b/feedfetcher.py
@@ -7,8 +7,14 @@ import json
 import time
 import sys
 import logging
+import os
 import settings
 import ssl
+import threading
+import urlparse
+from BaseHTTPServer import BaseHTTPRequestHandler, HTTPServer
+from rssfeed import RssFeed
+
 try:
     import feedparser
     import requests
@@ -18,10 +24,13 @@ except ImportError as exc:
     sys.exit(0)
 
 mattermost_webhook_url = settings.mattermost_webhook_url
+mattermost_integration_token = settings.mattermost_integration_token
 delay_between_pulls = settings.delay_between_pulls
 verify_cert = settings.verify_cert
 silent_mode = settings.silent_mode
 feeds = settings.feeds
+integration_listening_addr = settings.integration_listening_addr
+integration_listening_port = settings.integration_listening_port
 
 if (not verify_cert) and hasattr(ssl, '_create_unverified_context'):
     ssl._create_default_https_context = ssl._create_unverified_context
@@ -46,38 +55,121 @@ def post_text(text, username, channel, iconurl):
         logging.debug('Encountered error posting to Mattermost URL %s, status=%d, response_body=%s' %
                       (mattermost_webhook_url, r.status_code, r.json()))
 
+class RSSManagementRequestHandler(BaseHTTPRequestHandler):
+
+    def __init__(self, request, client_address, server):
+        self.data = {
+            'response_type': 'ephemeral'
+        }
+        if len(settings.integration_bot_name) > 0:
+            self.data['username'] = settings.integration_bot_name
+        if len(settings.integration_bot_img) > 0:
+            self.data['icon_url'] = settings.integration_bot_img
+
+        BaseHTTPRequestHandler.__init__(self, request, client_address, server)
+
+    def _check_header(self, token):
+        if token == mattermost_integration_token:
+            return True
+        else:
+            self.send_response(403)
+            return False
+
+    def _set_headers(self):
+        self.send_response(200)
+        self.send_header('Content-type', 'application/json')
+        self.end_headers()
+
+    def do_POST(self):
+        global feeds
+        content_len = int(self.headers.getheader('content-length', 0))
+        post_body = self.rfile.read(content_len)
+        params = urlparse.parse_qs(post_body)
+
+        if self._check_header(params.get('token')[0]):
+            self._set_headers()
+            commands = params.get('text', ['list'])[0].split(' ')
+
+            if commands[0] == 'add' and len(commands) >= 3 and len(commands) <= 8:
+                print(commands)
+                feed = RssFeed(
+                    commands[1],
+                    commands[2],
+                    commands[3] if len(commands) >= 4 and commands[3].startswith('http') else '',
+                    commands[1],
+                    params.get('channel_name', [settings.default_channel])[0],
+                    commands[4] == 'True' if len(commands) >= 5 else settings.default_show_name,
+                    commands[5] == 'True' if len(commands) >= 6 else settings.default_show_title,
+                    commands[6] == 'True' if len(commands) >= 7 else settings.default_show_description,
+                    commands[7] == 'True' if len(commands) >= 8 else settings.default_show_url
+                )
+
+                feed.LastTitle = 'Init'
+                fetching_feed(feed)
+                feeds.append(feed)
+                if os.path.isfile('feeds.env'):
+                    with open('feeds.env', 'a') as feeds_env:
+                        feeds_env.write(feed.env_definition())
+
+            elif commands[0] == 'remove' and len(commands) == 2:
+                feeds = [feed for feed in feeds if feed.Name != commands[1]]
+                if os.path.isfile('feeds.env'):
+                    with open('feeds.env', 'r') as feeds_env:
+                        lines = feeds_env.readlines()
+                    with open('feeds.env', 'w') as feeds_env:
+                        for line in [l for l in lines if not l.startswith('RSS_FEED_' + commands[1] + '=')]:
+                            feeds_env.write(line)
+
+            if commands[0] in ('list', 'add', 'remove'):
+                self.data['text'] = '---\n' + '\n'.join(['* [' + feed.Name + '](' + feed.Url + ') on @' + feed.Channel for feed in feeds]) + '\n---'
+            else:
+                self.data['text'] = 'Sorry, I don\'t understand your command: `' + params.get('text', '')[0] + '`'
+            self.wfile.write(json.dumps(self.data))
+
+def fetching_feed(feed):
+    try:
+        d = feedparser.parse(feed.Url)
+        feed.NewTitle = d['entries'][0]['title']
+        feed.ArticleUrl = d['entries'][0]['link']
+        feed.Description = d['entries'][0]['description']
+        if settings.skip_init_article and len(feed.LastTitle) <= 0:
+            if not silent_mode:
+                logging.debug('Initializing feed: ' + feed.Name + '. Skipping the last news: ' + feed.NewTitle)
+            feed.LastTitle = feed.NewTitle
+        elif feed.LastTitle != feed.NewTitle:
+            if not silent_mode:
+                logging.debug('Feed url: ' + feed.Url)
+                logging.debug('Title: ' + feed.NewTitle)
+                logging.debug('Link: ' + feed.ArticleUrl)
+                logging.debug('Posted text: ' + feed.jointext())
+            post_text(feed.jointext(), feed.User, feed.Channel, feed.Iconurl)
+            feed.LastTitle = feed.NewTitle
+        else:
+            if not silent_mode:
+                logging.debug('Nothing new. Waiting for good news...')
+    except:
+        logging.critical('Error fetching feed ' + feed.Url)
+        logging.exception(sys.exc_info()[0])
 
 if __name__ == "__main__":
     FORMAT = '%(asctime)-15s - %(message)s'
     logging.basicConfig(stream=sys.stderr, level=logging.DEBUG, format=FORMAT)
+
+    if len(mattermost_integration_token) == 0:
+        print('mattermost_integration_token must be configured to enable integration. Please see instructions in README.md')
+    else:
+        httpd = HTTPServer((integration_listening_addr, integration_listening_port), RSSManagementRequestHandler)
+
+        t = threading.Thread(target=httpd.serve_forever)
+        t.daemon = True
+        t.start()
+
     if len(mattermost_webhook_url) == 0:
         print('mattermost_webhook_url must be configured. Please see instructions in README.md')
         sys.exit()
 
     while 1:
         for feed in feeds:
-            try:
-                d = feedparser.parse(feed.Url)
-                feed.NewTitle = d['entries'][0]['title']
-                feed.ArticleUrl = d['entries'][0]['link']
-                feed.Description = d['entries'][0]['description']
-                if settings.skip_init_article and len(feed.LastTitle) <= 0:
-                    if not silent_mode:
-                        logging.debug('Initializing feed: ' + feed.Name + '. Skipping the last news: ' + feed.NewTitle)
-                    feed.LastTitle = feed.NewTitle
-                elif feed.LastTitle != feed.NewTitle:
-                    if not silent_mode:
-                        logging.debug('Feed url: ' + feed.Url)
-                        logging.debug('Title: ' + feed.NewTitle)
-                        logging.debug('Link: ' + feed.ArticleUrl)
-                        logging.debug('Posted text: ' + feed.jointext())
-                    post_text(feed.jointext(), feed.User, feed.Channel, feed.Iconurl)
-                    feed.LastTitle = feed.NewTitle
-                else:
-                    if not silent_mode:
-                        logging.debug('Nothing new. Waiting for good news...')
-            except:
-                logging.critical('Error fetching feed ' + feed.Url)
-                logging.exception(sys.exc_info()[0])
+            fetching_feed(feed)
 
         time.sleep(delay_between_pulls)

--- a/feeds.env.sample
+++ b/feeds.env.sample
@@ -1,2 +1,3 @@
-# RSS_FEED_<FeedName>='<FeedURL>[;<FeedLogoURL>]'
+# RSS_FEED_<FeedName>='<FeedURL>[;<FeedLogoURL>][;<ShowName>][;<ShowTitle>][;<ShowDescription>][;<ShowURL>]'
+# You can skip any parameter by directly putting a ;
 RSS_FEED_CommitStrip='https://www.commitstrip.com/en/feed/;https://www.commitstrip.com/wp-content/themes/krds_blog/images/logo_small.png'

--- a/rssfeed.py
+++ b/rssfeed.py
@@ -41,3 +41,15 @@ class RssFeed:
         if self.ShowUrl == True:
             text += self.ArticleUrl
         return text
+
+    def env_definition(self):
+        text = '\nRSS_FEED_' + self.Name
+        text += '=\'' + self.Url
+        text += ';' + self.Iconurl
+        text += ';' + self.Channel
+        text += ';' + str(self.ShowName)
+        text += ';' + str(self.ShowTitle)
+        text += ';' + str(self.ShowDescription)
+        text += ';' + str(self.ShowUrl)
+        text += '\''
+        return text

--- a/settings.py.docker
+++ b/settings.py.docker
@@ -7,6 +7,10 @@ from rssfeed import RssFeed
 # See also: https://github.com/mattermost/platform/blob/master/doc/integrations/webhooks/Incoming-Webhooks.md
 mattermost_webhook_url = environ['MATTERMOST_HOOK_URL']
 
+# Paste the Mattermost integration Token you created here
+# See also: https://docs.mattermost.com/developer/slash-commands.html
+mattermost_integration_token = environ.get('MATTERMOST_CMD_TOKEN' ,'')
+
 # Set the delay between feed pulls to your needs. 5 minutes should be okay.
 delay_between_pulls = environ.get('RSS_DELAY_PULL', 60 * 5)
 
@@ -15,6 +19,28 @@ verify_cert = environ.get('RSS_VERIFY_SSL_CERT', False)
 
 # Deactivate logging for debug purposes
 silent_mode = environ.get('RSS_SILENT_MODE', True)
+
+# Name of the user that responds to integration commands
+integration_bot_name = environ.get('INTEGRATION_BOT_NAME', 'RSS-Bot')
+
+# Image URL for the user that responds to integration commands
+integration_bot_img = environ.get('INTEGRATION_BOT_IMG', '')
+
+# Address integration bot must listen to ('' for every host)
+integration_listening_addr = environ.get('INTEGRATION_LISTENING_ADDR', '')
+
+# Port integration bot must listen to
+integration_listening_port = environ.get('INTEGRATION_LISTENING_PORT', 8080)
+
+# Don't publish the article fetched on the first run (avoid spamming when rebooting a lot the bot)
+skip_init_article = environ.get('RSS_SKIP_INIT_ARTICLE', True)
+
+# Default settings for the feeds
+default_show_name = environ.get('RSS_SHOW_NAME', True)
+default_show_title = environ.get('RSS_SHOW_TITLE', True)
+default_show_description = environ.get('RSS_SHOW_DESCR', True)
+default_show_url = environ.get('RSS_SHOW_URL', True)
+default_channel = environ['MATTERMOST_CHANNEL']
 
 # Your feeds come here:
 # RssFeed('Feed name', 'Feed URL', 'Image URL', 'Mattermost username', 'Mattermost channel',
@@ -25,13 +51,13 @@ silent_mode = environ.get('RSS_SILENT_MODE', True)
 # Set to False it if a feed doesnt´t work.
 # Hint: Channel overriding seems not to work with the channel 'Town Square'
 feeds = [RssFeed(
-                k.replace('RSS_FEED_', ''), 
-                v.partition(';')[0], 
-                v.partition(';')[2], 
-                environ.get('MATTERMOST_USERNAME', k.replace('RSS_FEED_', '')),
-                environ['MATTERMOST_CHANNEL'],
-                environ.get('RSS_SHOW_NAME', True),
-                environ.get('RSS_SHOW_TITLE', True),
-                environ.get('RSS_SHOW_DESCR', True),
-                environ.get('RSS_SHOW_URL', True)) 
+                k.replace('RSS_FEED_', ''),
+                v.split(';')[0],
+                v.split(';')[1] if v.count(';') >= 1 else '',
+                v.split(';')[2] if v.count(';') >= 2 else environ.get('MATTERMOST_USERNAME', k.replace('RSS_FEED_', '')),
+                v.split(';')[3] if v.count(';') >= 3 else default_channel,
+                v.split(';')[4] if v.count(';') >= 4 else default_show_name,
+                v.split(';')[5] if v.count(';') >= 5 else default_show_title,
+                v.split(';')[6] if v.count(';') >= 6 else default_show_description,
+                v.split(';')[7] if v.count(';') >= 7 else default_show_url)
         for k,v in environ.iteritems() if k.startswith('RSS_FEED_')]

--- a/settings.py.sample
+++ b/settings.py.sample
@@ -10,7 +10,7 @@ mattermost_webhook_url = 'https://<your-mattermost-webhook-URL>'
 
 # Paste the Mattermost integration Token you created here
 # See also: https://docs.mattermost.com/developer/slash-commands.html
-mattermost_integration_token = ''
+mattermost_integration_token = '<your-slash-command-token>'
 
 # Set the delay between feed pulls to your needs. 5 minutes should be okay.
 delay_between_pulls = 60 * 5

--- a/settings.py.sample
+++ b/settings.py.sample
@@ -5,8 +5,12 @@ __author__ = 'elpatron@mailbox.org'
 from rssfeed import RssFeed
 
 # Paste the Mattermost webhook URL you created here
-# See also: https://github.com/mattermost/platform/blob/master/doc/integrations/webhooks/Incoming-Webhooks.md
+# See also: https://docs.mattermost.com/developer/webhooks-incoming.html
 mattermost_webhook_url = 'https://<your-mattermost-webhook-URL>'
+
+# Paste the Mattermost integration Token you created here
+# See also: https://docs.mattermost.com/developer/slash-commands.html
+mattermost_integration_token = ''
 
 # Set the delay between feed pulls to your needs. 5 minutes should be okay.
 delay_between_pulls = 60 * 5
@@ -17,8 +21,27 @@ verify_cert = False
 # Deactivate logging for debug purposes
 silent_mode = True
 
+# Name of the user that responds to integration commands
+integration_bot_name = 'RSS-Bot'
+
+# Image URL for the user that responds to integration commands
+integration_bot_img = ''
+
+# Address integration bot must listen to ('' for every host)
+integration_listening_addr = ''
+
+# Port integration bot must listen to
+integration_listening_port = 80
+
 # Don't publish the article fetched on the first run (avoid spamming when rebooting a lot the bot)
 skip_init_article = True
+
+# Default settings for the feeds
+default_show_name = True
+default_show_title = True
+default_show_description = True
+default_show_url = True
+default_channel = ''
 
 # Your feeds come here:
 # RssFeed('Feed name', 'Feed URL', 'Image URL', 'Mattermost username', 'Mattermost channel',
@@ -40,4 +63,3 @@ feeds = [RssFeed('Heise News', 'http://heise.de.feedsportal.com/c/35207/f/653902
                  'http://www.mattermost.org/wp-content/uploads/2015/08/logomark.png', 'RSS-Bot', 'rss-test',
                  True, True, True, True)
          ]
-

--- a/settings.py.sample
+++ b/settings.py.sample
@@ -17,6 +17,9 @@ verify_cert = False
 # Deactivate logging for debug purposes
 silent_mode = True
 
+# Don't publish the article fetched on the first run (avoid spamming when rebooting a lot the bot)
+skip_init_article = True
+
 # Your feeds come here:
 # RssFeed('Feed name', 'Feed URL', 'Image URL', 'Mattermost username', 'Mattermost channel',
 # show name, show title, show description, show url)


### PR DESCRIPTION
Create a "slash-command" endpoint for Slack/Mattermost Integration:

* Allows the users to manage the RSS feeds directly from Mattermost without to restart the bot
* Persist the channels added or removed when used in Docker through the `feeds.env` file

Enable the skip of initial post of articles when the bot is booting.

(And I've tested carefully this time :) )