### PR TITLE
add check before fetching description

### DIFF
--- a/feedfetcher.py
+++ b/feedfetcher.py
@@ -60,7 +60,8 @@ if __name__ == "__main__":
                 d = feedparser.parse(feed.Url)
                 feed.NewTitle = d['entries'][0]['title']
                 feed.ArticleUrl = d['entries'][0]['link']
-                feed.Description = d['entries'][0]['description']
+                if feed.ShowDescription == True:
+                    feed.Description = d['entries'][0]['description']
                 if feed.LastTitle != feed.NewTitle:
                     if not silent_mode:
                         logging.debug('Feed url: ' + feed.Url)


### PR DESCRIPTION
feedfetcher.py  was failing failing on rss feeds without description, error log below 
```
Error fetching feed https://ci.centos.org/view/Devtools/job/devtools-build-run-che-build-master/rssAll
- <type 'exceptions.KeyError'>
Traceback (most recent call last):
  File "feedfetcher.py", line 63, in <module>
    feed.Description = d['entries'][0]['description']
```
so added a condition check before trying to fetch the description.