### PR TITLE
Quote unsafe characters in article URL

### DIFF
--- a/rssfeed.py
+++ b/rssfeed.py
@@ -3,6 +3,7 @@
 __author__ = 'elpatron@mailbox.org'
 
 import sys
+import urllib
 try:
     import html2text
 except ImportError as exc:
@@ -35,7 +36,7 @@ class RssFeed:
         if self.ShowName == True:
             text += "_" + self.Name + '_\n'
         if self.ShowTitle == True:
-            text += '### [' + self.NewTitle + '](' + self.ArticleUrl + ')\n'
+            text += '### [' + self.NewTitle + '](' + urllib.quote(self.ArticleUrl, safe=';/?:@&=+$,') + ')\n'
         if self.ShowDescription == True:
             text += self.Description + '\n'
         if self.ShowUrl == True:
@@ -53,3 +54,4 @@ class RssFeed:
         text += ';' + str(self.ShowUrl)
         text += '\''
         return text
+


### PR DESCRIPTION
Fixes an issue with URLs containing unsafe characters. E.g. URLs containing `'`s will not be rendered correctly as markdown.