### PR TITLE
Mount feeds file to container

### DIFF
--- a/docker-compose.yml.sample
+++ b/docker-compose.yml.sample
@@ -17,5 +17,6 @@ services:
       INTEGRATION_LISTENING_ADDR: ''
       INTEGRATION_LISTENING_PORT: '8080'
       MATTERMOST_CHANNEL: 'rss-stream'
-    env_file:
-      - feeds.env
+    volumes:
+      - feeds.env:/code/feeds.env:rw
+    user: root


### PR DESCRIPTION
This mounts the feeds to the container which is much better as it allows the feed configuration to be persisted