### PR TITLE
Revert "Mount feeds file to container"

### DIFF
--- a/docker-compose.yml.sample
+++ b/docker-compose.yml.sample
@@ -19,3 +19,5 @@ services:
       MATTERMOST_CHANNEL: 'rss-stream'
     env_file:
       - feeds.env
+    volumes:
+      - feeds.env:/code/feeds.env:rw

--- a/docker-compose.yml.sample
+++ b/docker-compose.yml.sample
@@ -17,6 +17,5 @@ services:
       INTEGRATION_LISTENING_ADDR: ''
       INTEGRATION_LISTENING_PORT: '8080'
       MATTERMOST_CHANNEL: 'rss-stream'
-    volumes:
-      - feeds.env:/code/feeds.env:rw
-    user: root
+    env_file:
+      - feeds.env


### PR DESCRIPTION
Reverts some parts of bitbackofen/Rss-Atom-Feed-Integration-for-Mattermost#29
As it break the initial loading of the feeds from the env vars.

cc @drallgood 