### PR TITLE
set stdout/stderr to be unbuffered

### DIFF
--- a/docker-compose.yml.sample
+++ b/docker-compose.yml.sample
@@ -17,6 +17,7 @@ services:
       INTEGRATION_LISTENING_ADDR: ''
       INTEGRATION_LISTENING_PORT: '8080'
       MATTERMOST_CHANNEL: 'rss-stream'
+      PYTHONUNBUFFERED: 1
     env_file:
       - feeds.env
     volumes:


### PR DESCRIPTION
to see log by  `docker logs` command in real time